### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/authentication/electron/app/main.js
+++ b/authentication/electron/app/main.js
@@ -39,7 +39,7 @@ app.on('ready', () => {
         new_window.webContents.on('did-navigate', (e, frame_url, httpResponseCode, httpStatusText) => {
             console.log('child url', frame_url);
             let url = new URL(frame_url);
-            let params = new URLSearchParams(url.hash.substr(1));
+            let params = new URLSearchParams(url.hash.slice(1));
             console.log(params);
             if (params.get('access_token')) {
                 // we got a token to use

--- a/authentication/implicit_auth/index.html
+++ b/authentication/implicit_auth/index.html
@@ -29,7 +29,7 @@
         document.getElementById('access_token').textContent = '';
 
         if (document.location.hash && document.location.hash != '') {
-            var parsedHash = new URLSearchParams(window.location.hash.substr(1));
+            var parsedHash = new URLSearchParams(window.location.hash.slice(1));
             if (parsedHash.get('access_token')) {
                 var access_token = parsedHash.get('access_token');
                 document.getElementById('access_token').textContent = 'Your Access Key from the #url: ' + access_token;

--- a/examples/team/index.html
+++ b/examples/team/index.html
@@ -669,11 +669,11 @@ function commaify (num) {
 
 
   if (remainders != 0) {
-    threes.push(num_string.substr(0, remainders));
+    threes.push(num_string.slice(0, remainders));
   }
 
   for (i = remainders; i < len; i += 3) {
-    threes.push(num_string.substr(i, 3));
+    threes.push(num_string.slice(i, i + 3));
   }
 
   return threes.join();


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.