### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These examples are testable on GitHub pages, and will prompt for implicit authen
     <thead><tr><th colspan="3">Auth Type Things</th></tr></thead>
     <tbody>
         <tr><td><a href="https://barrycarlyon.github.io/twitch_misc/authentication/implicit_auth/">How to Implicit auth</a></td><td><a href="https://github.com/BarryCarlyon/twitch_misc/tree/main/authentication/implicit_auth/">Source</a></td><td>For Client Side apps/websites</td></tr>
-        <tr><td><a href="https://barrycarlyon.github.io/twitch_misc/examples/token_checker/">Token Checker and Killer</a></td><td><a href="https://github.com/BarryCarlyon/twitch_misc/tree/main/examples/token_checker">Source</a></td><td>Validate Tokens and revoke then, handy if you find stuff in the wild that shouldn't be there!</tr>
+        <tr><td><a href="https://barrycarlyon.github.io/twitch_misc/examples/token_checker/">Token Checker and Killer</a></td><td><a href="https://github.com/BarryCarlyon/twitch_misc/tree/main/examples/token_checker">Source</a></td><td>Validate Tokens and revoke them, handy if you find stuff in the wild that shouldn't be there!</tr>
     </tbody>
     <thead><tr><th colspan="3">Examply Things</th></tr></thead>
     <tbody>


### PR DESCRIPTION
Spell correct
"Validate Tokens and revoke then" -> "Validate Tokens and revoke them"